### PR TITLE
67 remove sample options

### DIFF
--- a/R/mod_03_clustering.R
+++ b/R/mod_03_clustering.R
@@ -164,16 +164,6 @@ mod_03_clustering_ui <- function(id) {
           label = "Normalize genes (divide by SD)",
           value = FALSE
         ),
-        checkboxInput(
-          inputId = ns("sample_centering"),
-          label = "Center samples (substract mean)",
-          value = FALSE
-        ),
-        checkboxInput(
-          inputId = ns("sample_normalize"),
-          label = "Normalize samples(divide by SD)",
-          value = FALSE
-        ),
 
         conditionalPanel(
           condition = "input.cluster_panels == 'Heatmap/Enrichment'",
@@ -446,8 +436,8 @@ mod_03_clustering_server <- function(id, pre_process, idep_data, tab) {
         n_genes_max = input$n_genes,
         gene_centering = input$gene_centering,
         gene_normalize = input$gene_normalize,
-        sample_centering = input$sample_centering,
-        sample_normalize = input$sample_normalize,
+        sample_centering = FALSE,
+        sample_normalize = FALSE,
         all_gene_names = pre_process$all_gene_names(),
         select_gene_id = input$select_gene_id
       )
@@ -727,8 +717,8 @@ mod_03_clustering_server <- function(id, pre_process, idep_data, tab) {
         tree_data = pre_process$data(),
         gene_centering = input$gene_centering,
         gene_normalize = input$gene_normalize,
-        sample_centering = input$sample_centering,
-        sample_normalize = input$sample_normalize,
+        sample_centering = FALSE,
+        sample_normalize = FALSE,
         hclust_funs = hclust_funs,
         hclust_function = input$hclust_function,
         dist_funs = dist_funs,

--- a/R/mod_03_clustering.R
+++ b/R/mod_03_clustering.R
@@ -348,17 +348,21 @@ mod_03_clustering_server <- function(id, pre_process, idep_data, tab) {
     # Heatmap Colors ----------
     heatmap_colors <- list(
       "Green-Black-Red" = c("green", "black", "red"),
+      "Red-Black-Green" = c("red", "black", "green"), 
       "Blue-White-Red" = c("blue", "white", "red"),
       "Green-Black-Magenta" = c("green", "black", "magenta"),
       "Blue-Yellow-Red" = c("blue", "yellow", "red"),
-      "Blue-White-Brown" = c("blue", "white", "brown")
+      "Blue-White-Brown" = c("blue", "white", "brown"), 
+      "Orange-White-Blue" = c("orange", "white", "blue")
     )
     heatmap_choices <- c(
       "Green-Black-Red",
+      "Red-Black-Green", 
       "Blue-White-Red",
       "Green-Black-Magenta",
       "Blue-Yellow-Red",
-      "Blue-White-Brown"
+      "Blue-White-Brown", 
+      "Orange-White-Blue"
     )
     observe({
       updateSelectInput(

--- a/man/MDS_plot.Rd
+++ b/man/MDS_plot.Rd
@@ -4,7 +4,12 @@
 \alias{MDS_plot}
 \title{MDS FUNCTION}
 \usage{
-MDS_plot(data, sample_info)
+MDS_plot(
+  data,
+  sample_info,
+  selected_shape = "Sample_Name",
+  selected_color = "Sample_Name"
+)
 }
 \arguments{
 \item{data}{Data that has been through pre-processing}

--- a/man/PCA_plot.Rd
+++ b/man/PCA_plot.Rd
@@ -4,7 +4,14 @@
 \alias{PCA_plot}
 \title{Principal Component Analysis}
 \usage{
-PCA_plot(data, sample_info, PCAx = 1, PCAy = 2)
+PCA_plot(
+  data,
+  sample_info,
+  PCAx = 1,
+  PCAy = 2,
+  selected_color = "Sample_Name",
+  selected_shape = "Sample_Name"
+)
 }
 \arguments{
 \item{data}{Data that has been through pre-processing}

--- a/man/t_SNE_plot.Rd
+++ b/man/t_SNE_plot.Rd
@@ -4,7 +4,7 @@
 \alias{t_SNE_plot}
 \title{TSNE FUNCTION}
 \usage{
-t_SNE_plot(data, sample_info)
+t_SNE_plot(data, sample_info, selected_color, selected_shape)
 }
 \arguments{
 \item{data}{Data that has been through pre-processing}


### PR DESCRIPTION
Removed options for sampling centering/normalization 
The default is not FALSE for sample centering and sample normalization 
Let the underlying code, so some one using the code as a package could change the parameters 
Left the option for gene centering/normalization 

closes #67 